### PR TITLE
Link against original minizip (test for building with vcpkg)

### DIFF
--- a/src/kml/base/CMakeLists.txt
+++ b/src/kml/base/CMakeLists.txt
@@ -83,7 +83,7 @@ target_include_directories (kmlbase
 )
 
 target_link_libraries (kmlbase
-    PUBLIC MINIZIP::minizip
+    PUBLIC minizip::minizip
     PUBLIC uriparser::uriparser
     PUBLIC ZLIB::ZLIB
     PUBLIC expat::expat


### PR DESCRIPTION
Old minizip defines `unofficial::minizip::minizip`

New zlib with cmake-remake patches defines `MINIZIP::minizip`

As a test (because I'm trying to build libkml with vcpkg, which only knows old minizip), link libkml against old `minizip::minizip`.